### PR TITLE
fix: replicons table

### DIFF
--- a/src/bakta.js
+++ b/src/bakta.js
@@ -39,7 +39,7 @@ function loadJobs() {
 function generateRepliconTable(replicons) {
   return replicons
     .map((x) => [x.id, x.new, x.type, x.topology, x.name].join("\t"))
-    .join("\t");
+    .join("\n");
 }
 
 // eslint-disable-next-line no-unused-vars


### PR DESCRIPTION
Wrong line delimiter for the replicons .tsv (`\n` vs `\t`)
I encountered this issue during testing of our new rust based backend.  
It looks like the replicon table information was not used by the old backend, because the provided file was wrongly formatted.

This PR should fix this issue.